### PR TITLE
Fixed SH4 script for modern Lutris

### DIFF
--- a/silent-hill-4/scripts/silent-hill-4-lutris-install-script.yaml
+++ b/silent-hill-4/scripts/silent-hill-4-lutris-install-script.yaml
@@ -18,7 +18,6 @@ script:
   - settings_zip: https://github.com/eskay993/gamefiles/raw/main/silent-hill-4/files/settings.zip
   - randomizer_zip: https://github.com/HunterStanton/SilentHill4Randomizer/releases/download/beta-0.2.1/SH4.Randomizer.0.2.1.zip
   game:
-    arch: win32
     exe: drive_c/GOG Games/Silent Hill 4/SILENT HILL 4.exe
     prefix: $GAMEDIR
   installer:
@@ -45,7 +44,6 @@ script:
       - n: "No"
       preselect: y
   - task:
-      arch: win32
       description: Creating Wine prefix...
       name: create_prefix   
   - task:


### PR DESCRIPTION
Recent Lutris versions refuse to run games within a win32 prefix. This commit fixes the game installation by removing the arch win32 references. Tested successfully (including controller support and 1080p resolution) under Arch Linux (KDE, Wayland) and SteamOS 3.8 (Steam Machine)